### PR TITLE
Bump build number since for some reason the master build ran twice

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: '{{ hash_value }}'
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 


### PR DESCRIPTION
cc @conda-forge/core Unsure why this happened.

See the two things here https://anaconda.org/conda-forge/sendgrid/files